### PR TITLE
Enable bulk PDF of Delivery slip

### DIFF
--- a/src/Adapter/PDF/DeliverySlipPdfGenerator.php
+++ b/src/Adapter/PDF/DeliverySlipPdfGenerator.php
@@ -27,16 +27,15 @@
 namespace PrestaShop\PrestaShop\Adapter\PDF;
 
 use Context;
-use Order;
 use PDF;
-use PrestaShop\PrestaShop\Core\Exception\CoreException;
+use PrestaShop\PrestaShop\Core\PDF\Exception\PdfException;
 use PrestaShop\PrestaShop\Core\PDF\PDFGeneratorInterface;
-use RuntimeException;
 use Symfony\Component\Translation\TranslatorInterface;
-use Validate;
+use PrestaShopException;
+use PrestaShopCollection;
 
 /**
- * Generates delivery slip for given order
+ * Generates delivery slip for given orders
  *
  * @internal
  */
@@ -58,22 +57,16 @@ final class DeliverySlipPdfGenerator implements PDFGeneratorInterface
     /**
      * {@inheritdoc}
      */
-    public function generatePDF(array $orderId)
+    public function generatePDF(array $orderIds)
     {
-        if (count($orderId) !== 1) {
-            throw new CoreException(sprintf('"%s" supports generating delivery slip for single order only.', get_class($this)));
+        try {
+            $orders_invoice_collection = new PrestaShopCollection('OrderInvoice');
+            $orders_invoice_collection->where('id_order', 'in', $orderIds);
+    
+            $pdf = new PDF($orders_invoice_collection, PDF::TEMPLATE_DELIVERY_SLIP, Context::getContext()->smarty);
+            $pdf->render();
+        } catch (PrestaShopException $e) {
+            throw new PdfException('Something went wrong when trying to generate pdf', 0, $e);
         }
-
-        $orderId = reset($orderId);
-        $order = new Order((int) $orderId);
-
-        if (!Validate::isLoadedObject($order)) {
-            throw new RuntimeException($this->translator->trans('The order cannot be found within your database.', [], 'Admin.Orderscustomers.Notification'));
-        }
-
-        $order_invoice_collection = $order->getInvoicesCollection();
-
-        $pdf = new PDF($order_invoice_collection, PDF::TEMPLATE_DELIVERY_SLIP, Context::getContext()->smarty);
-        $pdf->render();
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Enable bulk for generating PDF of delivery slip
| Type?             | new feature
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26250
| How to test?      | Download a delivery slip on the back office
| Possible impacts? | N/a


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
